### PR TITLE
respecting workspace settings.json paths

### DIFF
--- a/src/CredoProvider.ts
+++ b/src/CredoProvider.ts
@@ -104,7 +104,7 @@ export default class CredoProvider {
 
     const vsConfig = vscode.workspace.getConfiguration(CredoProvider.extensionSettings, workspaceFolder);
     const config = this.getWorkspaceConfig(workspaceFolder);
-    const credoMixPath = path.join(workspaceFolder.uri.fsPath, 'deps', 'credo', 'mix.exs');
+    const workspacePath = workspaceFolder.uri.fsPath;
 
     config.enabled = vsConfig.get(Setting.Enable, true);
     config.command = vsConfig.get(Setting.Command, CredoProvider.defaultCommand);
@@ -113,6 +113,8 @@ export default class CredoProvider {
     config.diagnosticCollection = vscode.languages.createDiagnosticCollection(CredoProvider.extensionId);
     config.invalidCommand = false;
     config.credoCompiled = false;
+    const cwd = config.projectDir ? path.join(workspacePath, config.projectDir) : workspacePath;
+    const credoMixPath = path.join(cwd, 'deps', 'credo', 'mix.exs');
 
     if (!fs.existsSync(credoMixPath) && config.enabled) {
       this.channel.appendLine("Credo wasn't found in deps. Disabled.");


### PR DESCRIPTION
Prior to this change, if your current workspace had a .vscode directory with a settings.json in it, this extension was not pulling the "credo.projectDir" specified in settings.json.

Adjusted the code to pull from the current workspace settings. It appears that this extension is not successfully pulling the user level configs the user has set either, but that will need to be addressed in a future PR. In other words, if you set the global configuration for the options provided, the projectDir is not being set.

This is my first time ever working on a VSCode extension and I guessed my way through it in about 30 minutes, so please let me know if I missed anything. This change was tested against a monorepo and worked!