### PR TITLE
Don't stop everything on stderr

### DIFF
--- a/src/CredoProvider.ts
+++ b/src/CredoProvider.ts
@@ -182,10 +182,7 @@ export default class CredoProvider {
       try {
         cp.exec(command, options, (_error, stdout, stderr) => {
           if (stderr) {
-            config.invalidCommand = true;
-
             this.logError(`Command ${command} returned stderr:`);
-            return reject(stderr);
           }
 
           if (stdout) {


### PR DESCRIPTION
Hey there! So I'm sure there is a more elegant way to handle this, but I'm seeing that having "compiler warnings" is enough to cause the provider to stop, and it won't start again until I reload vscode. So ideally we'd just log that something bad happened, but keep trying/not stop everything, right?